### PR TITLE
:sparkles: Add PDF fixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ puppeteer-pdf --help
     -stb, --setTransparentBackground  Sets transparent background in resulting PDF. Uses the workaround described here: https://github.com/GoogleChrome/puppeteer/issues/2545#issuecomment-397590569
     -d, --debug                       Output Puppeteer PDF options
     -wu, --waitUntil [choice]         waitUntil accepts choices load, domcontentloaded, networkidle0, networkidle2. Defaults to 'networkidle2'. (default: networkidle2)
+    -bpdf --brokenPdf [file]          Broken PDF to fix
+    -fpdf --fixedPdf [file]           Fixed PDF
     -h, --help                        output usage information
 ```
 

--- a/main.js
+++ b/main.js
@@ -10,27 +10,53 @@ import { prepareOptions } from "./src/options";
   const cliOptions = cli.opts();
   const options = prepareOptions(cliOptions);
 
-  const executablePath = process.env.CHROME_BIN || "/usr/bin/google-chrome-stable";
-  const browser = await puppeteer.launch({
-    headless: 'new',
-    args: ["--no-sandbox"],
-    executablePath
-  });
-  const page = await browser.newPage();
+  if (options.brokenPdf !== undefined && options.fixedPdf !== undefined) {
+    const executablePath = process.env.FIREFOX_BIN || "/usr/bin/firefox"
+    const browser = await puppeteer.launch({
+      headless: true,
+      product: 'firefox',
+      executablePath: executablePath,
+    });
+    const page = await browser.newPage();
 
-  await page.setViewport({width: 1240, height: 1448, deviceScaleFactor: options.deviceScaleFactor || 1});
+    const html = `
+    <html>
+      <body style="margin: 0;">
+        <embed src="data:application/pdf;base64,${options.brokenPdf}" type="application/pdf" style="width: 100vw; height: 100vh;">
+      </body>
+    </html>
+    `
 
-  // Get URL / file path from first argument
-  const location = cli.args[0];
-  await page.goto(isUrl(location) ? location : fileUrl(location), {
-    waitUntil: options.waitUntil || "networkidle2"
-  });
-  // Output options if in debug mode
-  if (options.debug) {
-    console.log(options);
+    await page.setContent(html);
+    await page.waitForSelector('embed[type="application/pdf"]');
+
+    await page.pdf({path: options.fixedPdf, printBackground: true});
+
+    await browser.close();
+
+  } else  {
+    const executablePath = process.env.CHROME_BIN || "/usr/bin/google-chrome-stable";
+    const browser = await puppeteer.launch({
+      headless: 'new',
+      args: ["--no-sandbox"],
+      executablePath
+    });
+    const page = await browser.newPage();
+
+    await page.setViewport({width: 1240, height: 1448, deviceScaleFactor: options.deviceScaleFactor || 1});
+
+    // Get URL / file path from first argument
+    const location = cli.args[0];
+    await page.goto(isUrl(location) ? location : fileUrl(location), {
+      waitUntil: options.waitUntil || "networkidle2"
+    });
+    // Output options if in debug mode
+    if (options.debug) {
+      console.log(options);
+    }
+
+    await page.pdf(options);
+
+    await browser.close();
   }
-
-  await page.pdf(options);
-
-  await browser.close();
 })();

--- a/main.js
+++ b/main.js
@@ -5,58 +5,38 @@ import puppeteer from "puppeteer";
 
 import cli from "./src/cli";
 import { prepareOptions } from "./src/options";
+import fixBrokenPdf from "./src/fixBrokenPdf";
 
 (async () => {
   const cliOptions = cli.opts();
   const options = prepareOptions(cliOptions);
 
   if (options.brokenPdf !== undefined && options.fixedPdf !== undefined) {
-    const executablePath = process.env.FIREFOX_BIN || "/usr/bin/firefox"
-    const browser = await puppeteer.launch({
-      headless: true,
-      product: 'firefox',
-      executablePath: executablePath,
-    });
-    const page = await browser.newPage();
-
-    const html = `
-    <html>
-      <body style="margin: 0;">
-        <embed src="data:application/pdf;base64,${options.brokenPdf}" type="application/pdf" style="width: 100vw; height: 100vh;">
-      </body>
-    </html>
-    `
-
-    await page.setContent(html);
-    await page.waitForSelector('embed[type="application/pdf"]');
-
-    await page.pdf({path: options.fixedPdf, printBackground: true});
-
-    await browser.close();
-
-  } else  {
-    const executablePath = process.env.CHROME_BIN || "/usr/bin/google-chrome-stable";
-    const browser = await puppeteer.launch({
-      headless: 'new',
-      args: ["--no-sandbox"],
-      executablePath
-    });
-    const page = await browser.newPage();
-
-    await page.setViewport({width: 1240, height: 1448, deviceScaleFactor: options.deviceScaleFactor || 1});
-
-    // Get URL / file path from first argument
-    const location = cli.args[0];
-    await page.goto(isUrl(location) ? location : fileUrl(location), {
-      waitUntil: options.waitUntil || "networkidle2"
-    });
-    // Output options if in debug mode
-    if (options.debug) {
-      console.log(options);
-    }
-
-    await page.pdf(options);
-
-    await browser.close();
+    fixBrokenPdf(options);
+    return;
   }
+
+  const executablePath = process.env.CHROME_BIN || "/usr/bin/google-chrome-stable";
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ["--no-sandbox"],
+    executablePath
+  });
+  const page = await browser.newPage();
+
+  await page.setViewport({width: 1240, height: 1448, deviceScaleFactor: options.deviceScaleFactor || 1});
+
+  // Get URL / file path from first argument
+  const location = cli.args[0];
+  await page.goto(isUrl(location) ? location : fileUrl(location), {
+    waitUntil: options.waitUntil || "networkidle2"
+  });
+  // Output options if in debug mode
+  if (options.debug) {
+    console.log(options);
+  }
+
+  await page.pdf(options);
+
+  await browser.close();
 })();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contractbook/puppeteer-pdf",
   "author": "Patryk Domałeczny <patryk.domaleczny@gmail.com>",
-  "version": "1.4.0",
+  "version": "1.6.0",
   "description": "A command line tool to generate PDF from URLs with electron.",
   "preferGlobal": true,
   "bin": "./puppeteer-pdf.js",

--- a/src/cli.js
+++ b/src/cli.js
@@ -67,6 +67,8 @@ program
     "networkidle2"
   )
   .option("-oBg, --omitBackground", "Omits background", false)
+  .option("-bpdf --brokenPdf [file]", "Broken PDF to fix")
+  .option("-fpdf --fixedPdf [file]", "Fixed PDF")
   .parse(process.argv);
 
 export default program;

--- a/src/fixBrokenPdf.js
+++ b/src/fixBrokenPdf.js
@@ -1,0 +1,30 @@
+import puppeteer from "puppeteer";
+
+const fixBrokenPdf = async (options) => {
+  const executablePath = process.env.FIREFOX_BIN || "/usr/bin/firefox"
+
+  const browser = await puppeteer.launch({
+    headless: true,
+    product: 'firefox',
+    executablePath: executablePath,
+  });
+
+  const page = await browser.newPage();
+
+  const html = `
+  <html>
+    <body style="margin: 0;">
+      <embed src="data:application/pdf;base64,${options.brokenPdf}" type="application/pdf" style="width: 100vw; height: 100vh;">
+    </body>
+  </html>
+  `
+
+  await page.setContent(html);
+  await page.waitForSelector('embed[type="application/pdf"]');
+
+  await page.pdf({path: options.fixedPdf, printBackground: true});
+
+  await browser.close();
+}
+
+export default fixBrokenPdf;

--- a/src/options.js
+++ b/src/options.js
@@ -19,10 +19,19 @@ export const prepareOptions = (optionsFromCLI) =>
       }
     }
 
-    const optionValue = ["headerTemplate", "footerTemplate"].includes(optionKey) &&
-      value.startsWith("file://")
-        ? fs.readFileSync(value.replace("file://", ""), "utf-8")
-        : value;
+    let optionValue = value;
+
+    if (['headerTemplate', 'footerTemplate'].includes(optionKey) && value.startsWith('file://')) {
+      optionValue = fs.readFileSync(value.replace('file://', ''), 'utf-8');
+    }
+
+    if (['brokenPdf'].includes(optionKey)) {
+      optionValue = fs.readFileSync(value.replace('file://', '')).toString('base64');
+    }
+
+    if (['fixedPdf'].includes(optionKey)) {
+      optionValue = value.replace('file://', '');
+    }
 
     return {
       ...acc,


### PR DESCRIPTION
This PR adds two options for fixing:

- [x] Broken PDFs.
- [x] PDFs without embedded fonts.

We can call  `puppeteer-pdf` as:

```bash
$ ./puppeteer-pdf.js --brokenPdf "/path/to/my/broken/file.pdf" --fixedPdf "/path/to/fixed/file.pdf"
```

> **There's a known drawback:** The resulting file will have only one page, so it's better to split PDFs in several pages, fixed every single one of them and finally merge them

![](https://media.giphy.com/media/KmHueA88mFABT9GkkR/giphy.gif)