### PR TITLE
Use old headless mode since we switch chromium version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contractbook/puppeteer-pdf",
   "author": "Patryk Domałeczny <patryk.domaleczny@gmail.com>",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "A command line tool to generate PDF from URLs with electron.",
   "preferGlobal": true,
   "bin": "./puppeteer-pdf.js",

--- a/puppeteer-pdf.js
+++ b/puppeteer-pdf.js
@@ -129,7 +129,7 @@ var fixBrokenPdf_default = fixBrokenPdf;
   }
   const executablePath = process.env.CHROME_BIN || "/usr/bin/google-chrome-stable";
   const browser = await puppeteer2.launch({
-    headless: "new",
+    headless: "old",
     args: [
       "--no-sandbox",
       "--single-process",


### PR DESCRIPTION
New alpine in file service means new chromium browser, they made changes in the headless mode. I tested upgrading puppeteer to latest version, unfortunately it does not want to play nicely with Chrome 123 in any of the headless modes. As such I'm leaving puppeteer version as is and switching to old headless mode as this seems to be working properly.