### PR TITLE
Remove --single-process flag

### DIFF
--- a/main.js
+++ b/main.js
@@ -21,7 +21,6 @@ import fixBrokenPdf from "./src/fixBrokenPdf";
     headless: 'new',
     args: [
       "--no-sandbox",
-      "--single-process",
       "--no-zygote",
       "--disable-gpu"
     ],


### PR DESCRIPTION
This flag is causing Puppeteer to hang on recent Alpine / Chromium, see:

https://github.com/puppeteer/puppeteer/issues/11640#issuecomment-2243267991
https://github.com/puppeteer/puppeteer/issues/11640#issuecomment-2243353372

I believe this flag was added in order to prevent excessive Chromium zombie processes. Currently, there's https://github.com/Contractbook/file_service/pull/645 that ensures number of dead process don't go out of hand by restarting file-service in production every 6 hours.

I'm choosing to trade the flag for running more up-to-date version of Chromium + Alpine for file service. Separately, if we want to make the situation with zombie processes better, we should revisit `erlexec` approach: https://github.com/Contractbook/file_service/pull/735.