### PR TITLE
Add new option `--png` to generate a bitmap screenshot in favor of a PDF

### DIFF
--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@ import fixBrokenPdf from "./src/fixBrokenPdf";
 
 (async () => {
   const cliOptions = cli.opts();
-  const options = prepareOptions(cliOptions);
+  var options = prepareOptions(cliOptions);
 
   if (options.brokenPdf !== undefined && options.fixedPdf !== undefined) {
     fixBrokenPdf(options);
@@ -29,7 +29,22 @@ import fixBrokenPdf from "./src/fixBrokenPdf";
   const page = await browser.newPage();
 
   try {
-    await page.setViewport({width: 1240, height: 1448, deviceScaleFactor: options.deviceScaleFactor || 1});
+    // Allow setting the size for PNG output but ignore the option if it is
+    // not a valid plain number or if no PNG is to be generated. In all of the
+    // ignore cases, use the supplied defaultValue.
+    const numWithDefault = (optionValue, defaultValue) => {
+      if (options.png) {
+        const tryInt = parseInt(optionValue);
+        return Number.isNaN(tryInt) ? defaultValue : tryInt;
+      } else {
+        return defaultValue;
+      }
+    }
+    await page.setViewport({
+      width: numWithDefault(options.width, 1240),
+      height: numWithDefault(options.height, 1448),
+      deviceScaleFactor: options.deviceScaleFactor || 1
+    });
 
     // Get URL / file path from first argument
     const location = cli.args[0];
@@ -41,7 +56,20 @@ import fixBrokenPdf from "./src/fixBrokenPdf";
       console.log(options);
     }
 
-    await page.pdf(options);
+    if (options.png) {
+      // cross out the options which are supported (explicitly processed) but
+      // not valid options to page.screenshot function. Effectively this leaves
+      // only the `omitBackground` and `path` parameters active
+      delete options.png;
+      delete options.deviceScaleFactor;
+      delete options.width;
+      delete options.height;
+      options.fullPage = true;
+      await page.screenshot(options);
+    } else {
+      delete options.png;
+      await page.pdf(options);
+    }
 
     await browser.close();
   } catch(e) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -41,7 +41,7 @@ program
     "Paper width, accepts values labeled with units."
   )
   .option(
-    "-h, --heigh [height]",
+    "-h, --height [height]",
     "Paper height, accepts values labeled with units."
   )
   .option(

--- a/src/cli.js
+++ b/src/cli.js
@@ -69,6 +69,7 @@ program
   .option("-oBg, --omitBackground", "Omits background", false)
   .option("-bpdf --brokenPdf [file]", "Broken PDF to fix")
   .option("-fpdf --fixedPdf [file]", "Fixed PDF")
+  .option("--png", "Output image file rather than PDF", false)
   .parse(process.argv);
 
 export default program;


### PR DESCRIPTION
This allows using puppeteer-pdf as a replacement for wkhtmltoimage in addition to wkhtmltopdf. This is not equivalent to converting first to PDF and then to PNG because the image is generated to cover the entire page without any page breaks.

Example invocation:

	CHROME_BIN=/usr/bin/chromium ./puppeteer-pdf.js --png -w 800 -p test.png https://masysma.net/31/web_main.xhtml

So far, the only supported options together with `--png` are the following ones: -w, -h, -oBg, -p and -s